### PR TITLE
Increase max size limit from 500 to 10000

### DIFF
--- a/src/Parameter/SizeParameter.php
+++ b/src/Parameter/SizeParameter.php
@@ -12,7 +12,7 @@ class SizeParameter extends AbstractParameter
 {
     #[Constraints\NotNull]
     #[Constraints\Type('int')]
-    #[Constraints\Range(min: 1, max: 500)]
+    #[Constraints\Range(min: 1, max: 10000)]
     protected int $size;
 
     #[DataQuery\RequiredParameter(parameterName: 'size')]


### PR DESCRIPTION
## Summary
- Erhöht das maximale Limit für die Anzahl der Ergebnisse pro Anfrage von 500 auf 10.000
- Ändert die Validation-Constraint in `SizeParameter.php`

## Test plan
- [ ] Anfragen mit `size=500` funktionieren weiterhin
- [ ] Anfragen mit `size=5000` werden akzeptiert
- [ ] Anfragen mit `size=10000` werden akzeptiert
- [ ] Anfragen mit `size=10001` werden abgelehnt

🤖 Generated with [Claude Code](https://claude.com/claude-code)