### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "require": {
         "php": "^8.3",
         "ruflin/elastica": "^7.0",
-        "symfony/framework-bundle": "^4.0|^5.0|^6.0|^7.0",
-        "symfony/validator": "^4.0|^5.0|^6.0|^7.0"
+        "symfony/framework-bundle": "^4.0|^5.0|^6.0|^7.0|^8.0",
+        "symfony/validator": "^4.0|^5.0|^6.0|^7.0|^8.0"
 
     },
     "suggest": {


### PR DESCRIPTION
## Summary
- Add `^8.0` to version constraints for `symfony/framework-bundle` and `symfony/validator`

## Test plan
- [ ] Verify composer resolves dependencies correctly with Symfony 8
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)