### PR TITLE
Exclude PaginatedResult from service autodiscovery

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,7 +5,7 @@ services:
         public: true
 
     MalteHuebner\DataQueryBundle\:
-        resource: '../src/{DataQueryManager,Factory,FieldList,FinderFactory,Manager,PaginatedResult,Parameter,Query,RequestParameterList,Validator}'
+        resource: '../src/{DataQueryManager,Factory,FieldList,FinderFactory,Manager,Parameter,Query,RequestParameterList,Validator}'
         exclude: '../src/{DependencyInjection,Factory/ConflictResolver,Factory/ValueAssigner/ValueType.php,RequestParameterList/ArrayToListConverter.php,RequestParameterList/QueryStringToListConverter.php,RequestParameterList/RequestToListConverter.php,tests,MalteHuebnerDataQueryBundle}'
 
     Psr\Container\ContainerInterface:


### PR DESCRIPTION
## Summary
- Remove `PaginatedResult` from the resource scanning in `config/services.yaml`
- `PaginatedResult` is a value object with required constructor arguments (`$data`, `$page`, `$size`, `$totalItems`) that cannot be autowired, causing container compilation to fail

Closes #28

## Test plan
- [ ] Verify Symfony container compiles without errors when the bundle is loaded
- [ ] Verify `PaginatedResult` can still be instantiated manually in application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)