### PR TITLE
Throw 404 EntityNotFoundException when query entity cannot be resolved

### DIFF
--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace MalteHuebner\DataQueryBundle\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class EntityNotFoundException extends DataQueryException implements HttpExceptionInterface
+{
+    public function __construct(string $parameterName, string $parameterValue)
+    {
+        $message = sprintf('Could not find entity for query parameter "%s" with value "%s"', $parameterName, $parameterValue);
+
+        parent::__construct($message);
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+
+    public function getHeaders(): array
+    {
+        return [];
+    }
+}

--- a/src/Factory/ValueAssigner/ValueAssigner.php
+++ b/src/Factory/ValueAssigner/ValueAssigner.php
@@ -3,6 +3,7 @@
 namespace MalteHuebner\DataQueryBundle\Factory\ValueAssigner;
 
 use Doctrine\Persistence\ManagerRegistry;
+use MalteHuebner\DataQueryBundle\Exception\EntityNotFoundException;
 use MalteHuebner\DataQueryBundle\FieldList\ParameterFieldList\ParameterField;
 use MalteHuebner\DataQueryBundle\FieldList\QueryFieldList\QueryField;
 use MalteHuebner\DataQueryBundle\Parameter\ParameterInterface;
@@ -117,13 +118,13 @@ class ValueAssigner implements ValueAssignerInterface
 
         $entity = $repository->$methodName($queryParameterValue);
 
-        if ($queryField->getAccessor()) {
+        if (null !== $entity && $queryField->getAccessor()) {
             $accessMethodName = $queryField->getAccessor();
             $entity = $entity->$accessMethodName();
         }
 
         if (null === $entity) {
-            return $query;
+            throw new EntityNotFoundException($parameterName, (string) $queryParameterValue);
         }
 
         $setMethodName = $queryField->getMethodName();

--- a/tests/Factory/ValueAssigner/ValueAssignerTest.php
+++ b/tests/Factory/ValueAssigner/ValueAssignerTest.php
@@ -3,6 +3,8 @@
 namespace MalteHuebner\DataQueryBundle\Tests\Factory\ValueAssigner;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use MalteHuebner\DataQueryBundle\Exception\EntityNotFoundException;
 use MalteHuebner\DataQueryBundle\Factory\ValueAssigner\ValueAssigner;
 use MalteHuebner\DataQueryBundle\Factory\ValueAssigner\ValueAssignerInterface;
 use MalteHuebner\DataQueryBundle\Factory\ValueAssigner\ValueType;
@@ -11,6 +13,10 @@ use MalteHuebner\DataQueryBundle\FieldList\QueryFieldList\QueryField;
 use MalteHuebner\DataQueryBundle\Query\BoundingBoxQuery;
 use MalteHuebner\DataQueryBundle\Parameter\SizeParameter;
 use MalteHuebner\DataQueryBundle\RequestParameterList\RequestParameterList;
+use MalteHuebner\DataQueryBundle\Tests\Fixtures\SimpleEntity;
+use MalteHuebner\DataQueryBundle\Tests\Fixtures\SimpleEntityContainer;
+use MalteHuebner\DataQueryBundle\Tests\Fixtures\SimpleEntityContainerRepository;
+use MalteHuebner\DataQueryBundle\Tests\Fixtures\SimpleEntityQuery;
 use PHPUnit\Framework\TestCase;
 
 class ValueAssignerTest extends TestCase
@@ -308,5 +314,131 @@ class ValueAssignerTest extends TestCase
         $this->valueAssigner->assignParameterPropertyValueFromRequest($list, $parameter, $parameterField);
 
         $this->assertTrue(true);
+    }
+
+    public function testAssignQueryEntityValueAssignsEntityFromRepository(): void
+    {
+        $entity = new SimpleEntity();
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('find')->with('42')->willReturn($entity);
+
+        $this->managerRegistry->method('getRepository')->with(SimpleEntity::class)->willReturn($repository);
+
+        $list = new RequestParameterList();
+        $list->add('simpleEntityId', '42');
+
+        $query = new SimpleEntityQuery();
+
+        $queryField = new QueryField();
+        $queryField
+            ->setMethodName('setSimpleEntity')
+            ->setParameterName('simpleEntityId')
+            ->setType(SimpleEntity::class);
+
+        $this->valueAssigner->assignQueryPropertyValueFromRequest($list, $query, $queryField);
+
+        $this->assertSame($entity, $query->getSimpleEntity());
+    }
+
+    public function testAssignQueryEntityValueThrowsWhenEntityNotFound(): void
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->method('find')->willReturn(null);
+
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
+
+        $list = new RequestParameterList();
+        $list->add('simpleEntityId', '42');
+
+        $query = new SimpleEntityQuery();
+
+        $queryField = new QueryField();
+        $queryField
+            ->setMethodName('setSimpleEntity')
+            ->setParameterName('simpleEntityId')
+            ->setType(SimpleEntity::class);
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Could not find entity for query parameter "simpleEntityId" with value "42"');
+
+        $this->valueAssigner->assignQueryPropertyValueFromRequest($list, $query, $queryField);
+    }
+
+    public function testAssignQueryEntityValueWithAccessorAssignsAccessedEntity(): void
+    {
+        $entity = new SimpleEntity();
+        $repository = new SimpleEntityContainerRepository(new SimpleEntityContainer($entity));
+
+        $this->managerRegistry->method('getRepository')->with(SimpleEntityContainer::class)->willReturn($repository);
+
+        $list = new RequestParameterList();
+        $list->add('simpleEntitySlug', 'some-slug');
+
+        $query = new SimpleEntityQuery();
+
+        $queryField = new QueryField();
+        $queryField
+            ->setMethodName('setSimpleEntity')
+            ->setParameterName('simpleEntitySlug')
+            ->setType(SimpleEntity::class)
+            ->setRepository(SimpleEntityContainer::class)
+            ->setRepositoryMethod('findOneBySlug')
+            ->setAccessor('getSimpleEntity');
+
+        $this->valueAssigner->assignQueryPropertyValueFromRequest($list, $query, $queryField);
+
+        $this->assertSame($entity, $query->getSimpleEntity());
+    }
+
+    public function testAssignQueryEntityValueWithAccessorThrowsWhenLookupReturnsNull(): void
+    {
+        $repository = new SimpleEntityContainerRepository(null);
+
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
+
+        $list = new RequestParameterList();
+        $list->add('simpleEntitySlug', 'unknown-slug');
+
+        $query = new SimpleEntityQuery();
+
+        $queryField = new QueryField();
+        $queryField
+            ->setMethodName('setSimpleEntity')
+            ->setParameterName('simpleEntitySlug')
+            ->setType(SimpleEntity::class)
+            ->setRepository(SimpleEntityContainer::class)
+            ->setRepositoryMethod('findOneBySlug')
+            ->setAccessor('getSimpleEntity');
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage('Could not find entity for query parameter "simpleEntitySlug" with value "unknown-slug"');
+
+        $this->valueAssigner->assignQueryPropertyValueFromRequest($list, $query, $queryField);
+    }
+
+    public function testAssignQueryEntityValueThrowsWhenAccessorReturnsNull(): void
+    {
+        $repository = new SimpleEntityContainerRepository(new SimpleEntityContainer(null));
+
+        $this->managerRegistry->method('getRepository')->willReturn($repository);
+
+        $list = new RequestParameterList();
+        $list->add('simpleEntitySlug', 'some-slug');
+
+        $query = new SimpleEntityQuery();
+
+        $queryField = new QueryField();
+        $queryField
+            ->setMethodName('setSimpleEntity')
+            ->setParameterName('simpleEntitySlug')
+            ->setType(SimpleEntity::class)
+            ->setRepository(SimpleEntityContainer::class)
+            ->setRepositoryMethod('findOneBySlug')
+            ->setAccessor('getSimpleEntity');
+
+        $this->expectException(EntityNotFoundException::class);
+
+        $this->valueAssigner->assignQueryPropertyValueFromRequest($list, $query, $queryField);
     }
 }

--- a/tests/Fixtures/SimpleEntityContainer.php
+++ b/tests/Fixtures/SimpleEntityContainer.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace MalteHuebner\DataQueryBundle\Tests\Fixtures;
+
+class SimpleEntityContainer
+{
+    public function __construct(
+        private readonly ?SimpleEntity $simpleEntity = null
+    )
+    {
+
+    }
+
+    public function getSimpleEntity(): ?SimpleEntity
+    {
+        return $this->simpleEntity;
+    }
+}

--- a/tests/Fixtures/SimpleEntityContainerRepository.php
+++ b/tests/Fixtures/SimpleEntityContainerRepository.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace MalteHuebner\DataQueryBundle\Tests\Fixtures;
+
+use Doctrine\Persistence\ObjectRepository;
+
+/**
+ * @implements ObjectRepository<SimpleEntityContainer>
+ */
+class SimpleEntityContainerRepository implements ObjectRepository
+{
+    public function __construct(
+        private readonly ?SimpleEntityContainer $simpleEntityContainer = null
+    )
+    {
+
+    }
+
+    public function findOneBySlug(string $slug): ?SimpleEntityContainer
+    {
+        return $this->simpleEntityContainer;
+    }
+
+    public function find(mixed $id): ?object
+    {
+        return null;
+    }
+
+    public function findAll(): array
+    {
+        return [];
+    }
+
+    public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+    {
+        return [];
+    }
+
+    public function findOneBy(array $criteria): ?object
+    {
+        return null;
+    }
+
+    public function getClassName(): string
+    {
+        return SimpleEntityContainer::class;
+    }
+}

--- a/tests/Fixtures/SimpleEntityQuery.php
+++ b/tests/Fixtures/SimpleEntityQuery.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace MalteHuebner\DataQueryBundle\Tests\Fixtures;
+
+use MalteHuebner\DataQueryBundle\Query\AbstractQuery;
+
+class SimpleEntityQuery extends AbstractQuery
+{
+    private ?SimpleEntity $simpleEntity = null;
+
+    public function setSimpleEntity(SimpleEntity $simpleEntity): self
+    {
+        $this->simpleEntity = $simpleEntity;
+
+        return $this;
+    }
+
+    public function getSimpleEntity(): ?SimpleEntity
+    {
+        return $this->simpleEntity;
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a crash in `ValueAssigner::assignEntityValueFromRepository()`: the configured `accessor` was invoked on the repository lookup result **before** the null check. Any `RequiredQueryParameter` value that could not be resolved (e.g. `GET /api/ride?citySlug=unknown-city` on criticalmass.in) crashed with *"Call to a member function getCity() on null"* and surfaced as **500 Internal Server Error**.
- Without an accessor, a failed lookup previously skipped the filter silently, so an unknown slug returned the **unfiltered** entity list — wrong data instead of an error.
- Both cases now throw the new `EntityNotFoundException` (extends `DataQueryException`, implements Symfony's `HttpExceptionInterface` with status 404). Consuming applications render a proper **404 Not Found** automatically, no application-side changes required.
- Adds test coverage for the whole entity-from-repository path (plain `find`, custom repository method, accessor — found, not found, accessor returns null) plus reusable fixtures (`SimpleEntityQuery`, `SimpleEntityContainer`, `SimpleEntityContainerRepository`).

## Design notes

`EntityNotFoundException` implements `HttpExceptionInterface` instead of staying HTTP-agnostic so that Symfony's exception listener maps it to 404 out of the box. The bundle already targets Symfony applications (`symfony/framework-bundle` is a hard requirement) and the parameter resolution is inherently request-driven, mirroring how Doctrine's param converters throw `NotFoundHttpException`.

## Test Plan

- [x] `composer run tests` — 361 tests, 534 assertions, green (5 new tests)
- [x] `composer run phpstan` — no errors (verified with platform PHP 8.3 / Symfony 7, matching CI)
- [ ] After release: `GET https://criticalmass.in/api/ride?citySlug=unknown` returns 404 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)